### PR TITLE
Keep a console output code the same as before execution

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,9 @@ const USAGE = "Usage: " ++ NAME ++ " [OPTION]... [FILE]...";
 const DESCRIPTION = "Print FILE(s) to standard output.";
 const INFO = NAME ++ ": try \'me --help\' for more information";
 
+// TODO: To local scope
+var default_cp: c_uint = 65001;
+
 fn printUsage() void {
     debug.print("{s}\n", .{USAGE});
     debug.print("{s}", .{INFO});
@@ -30,11 +33,30 @@ fn printVersion() !void {
     try std.io.getStdOut().writer().print("me {s}", .{VERSION});
 }
 
-fn exit(code: u8, cp: c_uint) void {
+fn exit(code: u8) void {
     if (comptime is_windows) {
-        _ = std.os.windows.kernel32.SetConsoleOutputCP(cp);
+        _ = std.os.windows.kernel32.SetConsoleOutputCP(default_cp);
     }
     std.os.exit(code);
+}
+
+// Make a console output code is the same as before execution
+fn setAbortSignalHandler(comptime handler: *const fn () void) !void {
+    const handler_routine = struct {
+        fn handler_routine(dwCtrlType: std.os.windows.DWORD) callconv(std.os.windows.WINAPI) std.os.windows.BOOL {
+            if (dwCtrlType == std.os.windows.CTRL_C_EVENT) {
+                handler();
+                return std.os.windows.TRUE;
+            } else {
+                return std.os.windows.FALSE;
+            }
+        }
+    }.handler_routine;
+
+    try std.os.windows.SetConsoleCtrlHandler(handler_routine, true);
+}
+fn abortSignalHandler() void {
+    exit(0);
 }
 
 pub fn main() !void {
@@ -43,17 +65,17 @@ pub fn main() !void {
     const alc = gpa.allocator();
     const args = try std.process.argsAlloc(alc);
 
-    // Set console output code page to UTF-8
-    var default_cp: c_uint = 65001;
+    // Set a console output code page to UTF-8
     if (comptime is_windows) {
         default_cp = std.os.windows.kernel32.GetConsoleOutputCP();
+        try setAbortSignalHandler(abortSignalHandler);
         _ = std.os.windows.kernel32.SetConsoleOutputCP(65001);
     }
 
     defer std.process.argsFree(alc, args);
     if (args.len < 2) {
         printUsage();
-        exit(2, default_cp);
+        exit(2);
     }
 
     var files = std.ArrayList([]const u8).init(alc);
@@ -63,16 +85,16 @@ pub fn main() !void {
         if (std.mem.startsWith(u8, arg, "-")) {
             if (std.mem.eql(u8, arg, "--help")) {
                 try printHelp();
-                exit(0, default_cp);
+                exit(0);
             } else if (std.mem.eql(u8, arg, "--version")) {
                 try printVersion();
-                exit(0, default_cp);
+                exit(0);
             } else if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "--number")) {
                 has_numbers_flag = true;
             } else {
                 debug.print("{s}: invalid option {s}\n", .{ NAME, arg });
                 debug.print("{s}", .{INFO});
-                exit(2, default_cp);
+                exit(2);
             }
         } else {
             try files.append(arg);
@@ -82,7 +104,7 @@ pub fn main() !void {
         try cat(alc, filename, .{ .number = has_numbers_flag });
     }
     files.deinit();
-    exit(0, default_cp);
+    exit(0);
 }
 
 test {


### PR DESCRIPTION
Add abort signal handler for keeping a console output code the same as before execution.